### PR TITLE
Fix - Escape special characters in nicknames #14

### DIFF
--- a/lib/catalog.js
+++ b/lib/catalog.js
@@ -250,7 +250,7 @@ class Catalog {
 
                 wRef.texth(useForceIndex && this.list[idx].forceIndex !== false ? (this.list[idx].forceIndex + 1) : (idx + 1));
                 wRef.text(') ', true);
-                wRef.text(this.list[idx].nick, false, true);
+                wRef.text(this.normalizeDiscordNick(this.list[idx].nick), false, true);
 
                 if (this.list[idx].tag != false) {
                     wRef.texth('[');
@@ -271,6 +271,10 @@ class Catalog {
         }
 
         return wRef;
+    }
+
+    normalizeDiscordNick(nick) {
+        return nick.replace(/`/g, /\\`/).replace(/\*/g, '\\*').replace(/_/g, '\\_').replace(/~/g, '\\~');
     }
 
     addStatusReadableShort(wRef, channelKey, operRef) {

--- a/lib/operator.js
+++ b/lib/operator.js
@@ -1472,16 +1472,19 @@ class Operator {
         }
     }
 
+    removeSpecialCharacters(msg) {
+        return msg.replace(/\\/g, '');
+    }
+
     sendMsgArray(channelKey, list, idx, privPartRef = null, flags = false) {
         if (idx < list.length && list[idx] == "::DELETE") {
             // nothing ...
 
         } else if (privPartRef != null) {
             privPartRef.noticeMessage(this, list[idx]);
-
         } else {
 
-            const msgIrc = list[idx].getIrc();
+            const msgIrc = this.removeSpecialCharacters(list[idx].getIrc());
             const msgStr = new discord.RichEmbed();
 
             msgStr.setDescription(list[idx].getDiscord());


### PR DESCRIPTION
Escaping characters in nickname for `list` variations with special characters: `_*~
It also strip the escaping to IRC messages
This fixes #14 