### PR TITLE
Changed: Discord id ban, now shows real nick

### DIFF
--- a/lib/op_ban.js
+++ b/lib/op_ban.js
@@ -78,10 +78,10 @@ class OpBan {
                 wRef = WordCo.cre();
 
                 if (nBanDuration == 0) {
-                    wRef.text('User ').texth(banNick).text(' was permanently banned by ').texth(partRef.nick).text('for: ').texth(nBanReason);
+                    wRef.text('User ').texth(cPartRef.nick).text(' was permanently banned by ').texth(partRef.nick).text('for: ').texth(nBanReason);
 
                 } else {
-                    wRef.text('User ').texth(banNick).text(' was banned by ').texth(partRef.nick).text(' for ').texth(nBanDuration).text(' hours: ').texth(nBanReason);
+                    wRef.text('User ').texth(cPartRef.nick).text(' was banned by ').texth(partRef.nick).text(' for ').texth(nBanDuration).text(' hours: ').texth(nBanReason);
                 }
 
                 if (nBanMask.length > 0) {


### PR DESCRIPTION
When banning discord user by id, it will show the banned nick instead of discord id