### PR TITLE
Reset areCaptainsSet after every picking

### DIFF
--- a/lib/channel_action.js
+++ b/lib/channel_action.js
@@ -362,7 +362,9 @@ class ChannelAction {
 
             this.statsRef.saveGameToStats(this.gameRef, this.voteRef);
 
-            this.gameHasFinished();
+	      this.gameRef.areCaptainsSet = false;
+
+	      this.gameHasFinished();
 
             this.saveState();
 


### PR DESCRIPTION
`gameRef` gets created once pug starts. that's why some variables are not reset while people are joining, such as `areCaptainsSet`